### PR TITLE
Fix malformed URL in mutateLevel API requests

### DIFF
--- a/frontend/src/app/(routes)/niveis/page.tsx
+++ b/frontend/src/app/(routes)/niveis/page.tsx
@@ -45,7 +45,7 @@ export default function LevelsPage() {
   };
 
   const mutateLevel = async({method, levelId, levelName}: mutateLevelProps) => {
-    const url = levelId ? `http://localhost:5001/api/v1//niveis/${levelId}` : `http://localhost:5001/api/v1//niveis`;
+    const url = levelId ? `http://localhost:5001/api/v1/niveis/${levelId}` : `http://localhost:5001/api/v1/niveis`;
 
     const res = await fetch(url, {
       method,


### PR DESCRIPTION
This pull request addresses an issue with improper URL formatting in the `mutateLevel` function. An extra slash in the API endpoint URL was removed to ensure accurate request handling, preventing potential failures caused by malformed URLs.